### PR TITLE
Remove unused endpoint

### DIFF
--- a/tenant_security_request.go
+++ b/tenant_security_request.go
@@ -12,14 +12,13 @@ import (
 
 // Paths that refer to TSP REST endpoints.
 const (
-	tspAPIPrefixString         string = "/api/1/"
-	wrapEndpointStr            string = "document/wrap"
-	batchWrapEndpointStr       string = "document/batch-wrap"
-	unwrapEndpointStr          string = "document/unwrap"
-	batchUnwrapEndpointStr     string = "document/batch-unwrap"
-	rekeyEndpointStr           string = "document/rekey"
-	tenantKeyDeriveEndpointStr string = "key/derive"
-	securityEventEndpointStr   string = "event/security-event"
+	tspAPIPrefixString       string = "/api/1/"
+	wrapEndpointStr          string = "document/wrap"
+	batchWrapEndpointStr     string = "document/batch-wrap"
+	unwrapEndpointStr        string = "document/unwrap"
+	batchUnwrapEndpointStr   string = "document/batch-unwrap"
+	rekeyEndpointStr         string = "document/rekey"
+	securityEventEndpointStr string = "event/security-event"
 )
 
 var tspAPIPrefix *url.URL
@@ -28,13 +27,12 @@ type tspEndpoint url.URL
 
 // These values can be used like an enum of valid TSP endpoints.
 var (
-	wrapEndpoint            *tspEndpoint
-	batchWrapEndpoint       *tspEndpoint
-	unwrapEndpoint          *tspEndpoint
-	batchUnwrapEndpoint     *tspEndpoint
-	rekeyEndpoint           *tspEndpoint
-	tenantKeyDeriveEndpoint *tspEndpoint
-	securityEventEndpoint   *tspEndpoint
+	wrapEndpoint          *tspEndpoint
+	batchWrapEndpoint     *tspEndpoint
+	unwrapEndpoint        *tspEndpoint
+	batchUnwrapEndpoint   *tspEndpoint
+	rekeyEndpoint         *tspEndpoint
+	securityEventEndpoint *tspEndpoint
 )
 
 func init() {
@@ -57,7 +55,6 @@ func init() {
 	unwrapEndpoint = parseURL(unwrapEndpointStr, "unwrapEndpoint")
 	batchUnwrapEndpoint = parseURL(batchUnwrapEndpointStr, "batchUnwrapEndpoint")
 	rekeyEndpoint = parseURL(rekeyEndpointStr, "rekeyEndpoint")
-	tenantKeyDeriveEndpoint = parseURL(tenantKeyDeriveEndpointStr, "tenantKeyDeriveEndpoint")
 	securityEventEndpoint = parseURL(securityEventEndpointStr, "securityEventEndpoint")
 }
 


### PR DESCRIPTION
I realized that this endpoint is only currently used by the closed-source cloaked search TSP; it is not present in java, nodejs, or php. Therefore, we don't need to implement it at this time.