### PR TITLE
Add changelog, change bump version workflow, retract v0.1.x

### DIFF
--- a/.github/bump-version-patch.yaml
+++ b/.github/bump-version-patch.yaml
@@ -18,3 +18,7 @@
       cd foo
       go mod init example.com/m
       go get github.com/IronCoreLabs/tenant-security-client-go@${{ steps.versions.outputs.release }}
+
+# Pushing the tag will automatically publish to pkg.go.dev, so only bump version manually (to release)
+- op: remove
+  path: /on/push

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -4,9 +4,6 @@
 
 name: Bump Version
 'on':
-  push:
-    branches:
-    - main
   workflow_dispatch:
     inputs:
       version:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## v0.2.2
+
+- Retract v0.1.x of the tenant-security-client-go
+
+## v0.2.1
+
+- Handle negatives values for TenantSecurityClient parallelism better
+
+## v0.2.0
+
+- Initial beta release of the SDK

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,4 +2,4 @@
 
 Because pushing a tag of the form v`x.x.x` publishes to pkg.go.dev, this repo does not automatically bump versions on push to `main`.
 Therefore, the release process is simply to manually run the [Bump Version](https://github.com/IronCoreLabs/tenant-security-client-go/actions/workflows/bump-version.yaml)
-workflow with the new desired version number (remember to start the version with a `v`).
+workflow with the new desired version number (the workflow will add the `v` at the start for you, so only enter the version number).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,5 @@
+## Releasing
+
+Because pushing a tag of the form v`x.x.x` publishes to pkg.go.dev, this repo does not automatically bump versions on push to `main`.
+Therefore, the release process is simply to manually run the [Bump Version](https://github.com/IronCoreLabs/tenant-security-client-go/actions/workflows/bump-version.yaml)
+workflow with the new desired version number (remember to start the version with a `v`).

--- a/go.mod
+++ b/go.mod
@@ -12,3 +12,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )
+
+retract [v0.1.0, v0.1.18] // Published accidentally.


### PR DESCRIPTION
- Because pushing a tag like v0.1.0 automatically publishes the version to pkg.go.dev, we only want Bump Version to run when we manually trigger it. Removed the automatic trigger from the workflow.
- Added CHANGELOG.md and RELEASING.md
- Added `retract` statements for v0.1.x of the TSC-go so that they won't be accidentally depended on