### PR TITLE
Fix a variable reference.

### DIFF
--- a/.github/bump-version-patch.yaml
+++ b/.github/bump-version-patch.yaml
@@ -13,7 +13,7 @@
       mkdir foo
       cd foo
       go mod init example.com/m
-      go get github.com/IronCoreLabs/tenant-security-client-go@${{ steps.versions.outputs.release }}
+      go get github.com/IronCoreLabs/tenant-security-client-go@${{ steps.release.outputs.release }}
 
 # Pushing the tag will automatically publish to pkg.go.dev, so only bump version manually (to release)
 - op: remove

--- a/.github/bump-version.bump.sh
+++ b/.github/bump-version.bump.sh
@@ -61,6 +61,7 @@ if [ -z "${RELEASEVERS}" ] ; then
         ;;
     esac
 fi
+# The prefix is there to support Go's release naming conventions.
 echo "release=${BUMP_VERSION_RELEASE_PREFIX}${RELEASEVERS}" >> "$GITHUB_OUTPUT"
 
 # Derive a new bumped version from the release version.

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -8,6 +8,9 @@ name: Bump Version
     inputs:
       version:
         description: New semver release version.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 env:
   MODE: release
 jobs:
@@ -90,7 +93,7 @@ jobs:
 
         go mod init example.com/m
 
-        go get github.com/IronCoreLabs/tenant-security-client-go@${{ steps.versions.outputs.release
+        go get github.com/IronCoreLabs/tenant-security-client-go@${{ steps.release.outputs.release
         }}
 
         '

--- a/.github/workflows/update-workflows.yaml
+++ b/.github/workflows/update-workflows.yaml
@@ -3,6 +3,9 @@
 # For docs, see github-actions in the IronCoreLabs/depot repo.
 
 name: Update Workflows
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 'on':
   push:
     paths:


### PR DESCRIPTION
Variables were renamed when the bump-version workflow was rewritten. This workflow patch wasn't modified to use the new variable name, so it broke the workflow. This PR fixes the variable name.